### PR TITLE
Fix usage from console_script entry point

### DIFF
--- a/pyuac/admin.py
+++ b/pyuac/admin.py
@@ -67,6 +67,12 @@ def runAsAdmin(cmdLine=None, wait=True):
 
     if not cmdLine:
         cmdLine = [sys.executable] + sys.argv
+        if not os.path.exists(sys.argv[0]):
+            # When running an entry point, argv[0] is wrong
+            for ext in ('-script.py', '-script.pyw'):
+                if os.path.exists(sys.argv[0] + ext):
+                    cmdLine[1] = sys.argv[0] + ext
+                    break
         log.debug("Defaulting to runAsAdmin command line: %r", cmdLine)
     elif type(cmdLine) not in (tuple, list):
         raise ValueError("cmdLine is not a sequence.")


### PR DESCRIPTION
I noticed that when running from an entry point, argv[0] does not actually point to a file. For example, it will be `C:\Python3.8\Scripts\reprozip-windows` if running `C:\Python3.8\Scripts\reprozip-windows.exe`, and the script name is `C:\Python3.8\Scripts\reprozip-windows-script.py`.

This code adds the suffix if argv[0] doesn't exist but the script can be found.